### PR TITLE
Check for Keyring before inclusion

### DIFF
--- a/publishiza.php
+++ b/publishiza.php
@@ -44,14 +44,17 @@ function publishiza_plugins_loaded() {
 	require_once $plugin_path . 'includes/twitter.php';
 
 	// Service
-	require_once $plugin_path . 'keyring/includes/services/core/http-basic.php';
-	require_once $plugin_path . 'keyring/includes/services/core/oauth1.php';
-	require_once $plugin_path . 'keyring/includes/services/core/oauth2.php';
-	require_once $plugin_path . 'keyring/includes/services/extended/twitter.php';
+	if ( ! defined( 'KEYRING__VERSION' ) ) {
+		require_once $plugin_path . 'keyring/includes/services/core/http-basic.php';
+		require_once $plugin_path . 'keyring/includes/services/core/oauth1.php';
+		require_once $plugin_path . 'keyring/includes/services/core/oauth2.php';
+		require_once $plugin_path . 'keyring/includes/services/extended/twitter.php';
+	}
 	require_once $plugin_path . 'includes/service.php';
 
+
 	// Load translations
-	load_plugin_textdomain( 'publishiza', false, $plugin_path . 'assets/lang/' );	
+	load_plugin_textdomain( 'publishiza', false, $plugin_path . 'assets/lang/' );
 }
 add_action( 'plugins_loaded', 'publishiza_plugins_loaded' );
 

--- a/publishiza/includes/service.php
+++ b/publishiza/includes/service.php
@@ -4,7 +4,9 @@
 defined( 'ABSPATH' ) || exit;
 
 // Require parent service
-require_once dirname( dirname( __FILE__ ) ) . '/keyring/includes/services/extended/twitter.php';
+if ( ! class_exists( 'Keyring_Service_Twitter' ) ) {
+	require_once dirname( dirname( __FILE__ ) ) . '/keyring/includes/services/extended/twitter.php';
+}
 
 /**
  * Twitter service definition for Publishiza. Clean implementation of OAuth1
@@ -51,7 +53,7 @@ class Keyring_Service_Publishiza extends Keyring_Service_Twitter {
 	}
 
 	/**
-	 * 
+	 *
 	 * @since 1.0.0
 	 */
 	function basic_ui() {


### PR DESCRIPTION
On a site with Keyring already installed/activated, Publishiza 500s for redeclaring classes. This PR checks for `KEYRING__VERSION` and only requires the included keyring files when they are not present.

I didn't check if the plugin requires a certain version of Keyring to see if a more specific check was needed.